### PR TITLE
[#2] Resolve time range presets on runtime

### DIFF
--- a/lib/luminous/components.ex
+++ b/lib/luminous/components.ex
@@ -14,8 +14,7 @@ defmodule Luminous.Components do
   it also registers callbacks for reacting to panel loading states
   """
   def dashboard(
-        %{dashboard: dashboard, stats: stats, panel_statistics: panel_statistics, socket: socket} =
-          assigns
+        %{dashboard: dashboard, stats: stats, panel_statistics: panel_statistics} = assigns
       ) do
     ~H"""
     <.listeners />
@@ -26,7 +25,7 @@ defmodule Luminous.Components do
         <div class="flex flex-col md:flex-row justify-between">
           <div class="flex space-x-2 items-center">
             <%= for var <- dashboard.variables do %>
-            <.variable variable={var} link_fun={generate_link_fun(socket, dashboard)} />
+              <.variable variable={var} />
             <% end %>
           </div>
 
@@ -230,14 +229,14 @@ defmodule Luminous.Components do
     """
   end
 
-  def variable(%{variable: variable, link_fun: link_fun} = assigns) do
+  def variable(%{variable: variable} = assigns) do
     ~H"""
       <.dropdown
         id={"#{variable.id}-dropdown"}
         value={variable.current.label} description={variable.label}
         items={variable.values}
         let={%{label: label, value: value}}>
-        <%= live_patch label, to: link_fun.("#{variable.id}": value) %>
+        <div id={"#{variable.id}-#{value}"} phx-click="variable_updated" phx-value-variable={"#{variable.id}"} phx-value-value={"#{value}"}><%= label %></div>
       </.dropdown>
     """
   end

--- a/lib/luminous/components.ex
+++ b/lib/luminous/components.ex
@@ -2,7 +2,7 @@ defmodule Luminous.Components do
   use Phoenix.Component
   alias Phoenix.LiveView.JS
 
-  alias Luminous.{Dashboard, Query, Helpers}
+  alias Luminous.{Query, Helpers}
 
   @doc """
   the dashboard component is responsible for rendering all the necessary elements:
@@ -274,34 +274,6 @@ defmodule Luminous.Components do
       </ul>
     </div>
     """
-  end
-
-  def generate_link_fun(socket, dashboard) do
-    fn opts -> generate_link(socket, dashboard, opts) end
-  end
-
-  def generate_link(socket, dashboard, opts) do
-    var_args =
-      Enum.map(dashboard.variables, fn var ->
-        {var.id, Keyword.get(opts, var.id, var.current.value)}
-      end)
-
-    time_range_args = [
-      from:
-        Keyword.get(
-          opts,
-          :from,
-          DateTime.to_unix(dashboard.time_range_selector.current_time_range.from)
-        ),
-      to:
-        Keyword.get(
-          opts,
-          :to,
-          DateTime.to_unix(dashboard.time_range_selector.current_time_range.to)
-        )
-    ]
-
-    Dashboard.path(dashboard, socket, Keyword.merge(var_args, time_range_args))
   end
 
   def panel_id(panel), do: "panel-#{panel.id}"

--- a/lib/luminous/components.ex
+++ b/lib/luminous/components.ex
@@ -31,7 +31,7 @@ defmodule Luminous.Components do
           </div>
 
           <div class="flex space-x-2 items-center">
-            <.time_range dashboard={dashboard}, link_fun={generate_link_fun(socket, dashboard)} />
+            <.time_range dashboard={dashboard} />
           </div>
         </div>
       </div>
@@ -201,7 +201,7 @@ defmodule Luminous.Components do
     """
   end
 
-  def time_range(%{dashboard: dashboard, link_fun: link_fun} = assigns) do
+  def time_range(%{dashboard: dashboard} = assigns) do
     ~H"""
       <div class="btn btn-ghost no-animation cursor-default space-x-4 px-0 hover:bg-transparent">
         <div class="flex items-center outline outline-1 rounded-lg ">
@@ -213,9 +213,11 @@ defmodule Luminous.Components do
               </svg>
             </label>
             <ul x-show="open" id="preset-dropdown" tabindex="0" class="p-2 shadow menu dropdown-content bg-base-100 rounded-box min-w-max overflow-auto normal-case font-normal text-base">
-              <%= for preset <- dashboard.time_range_presets do %>
+              <%= for preset <- Luminous.TimeRangeSelector.presets() do %>
               <li>
-                <%= live_patch preset.label, to: link_fun.(from: DateTime.to_unix(preset.value.from), to: DateTime.to_unix(preset.value.to)), "@click": "open = false" %>
+                <div id={"time-range-preset-#{preset}"} phx-click="preset_time_range_selected" phx-value-preset={preset} @click="open = false">
+                  <%= preset %>
+                </div>
               </li>
               <% end %>
             </ul>

--- a/lib/luminous/dashboard.ex
+++ b/lib/luminous/dashboard.ex
@@ -69,7 +69,25 @@ defmodule Luminous.Dashboard do
   return the LV path for the specific dashboard based on its configuration
   """
   @spec path(t(), Phoenix.LiveView.Socket.t(), Keyword.t()) :: binary()
-  def path(dashboard, socket, args), do: dashboard.path.(socket, dashboard.action, args)
+  def path(dashboard, socket, params) do
+    var_params =
+      Enum.map(dashboard.variables, fn var ->
+        {var.id, Keyword.get(params, var.id, var.current.value)}
+      end)
+
+    time_range_params = [
+      from:
+        params
+        |> Keyword.get(:from, dashboard.time_range_selector.current_time_range.from)
+        |> DateTime.to_unix(),
+      to:
+        params
+        |> Keyword.get(:to, dashboard.time_range_selector.current_time_range.to)
+        |> DateTime.to_unix()
+    ]
+
+    dashboard.path.(socket, dashboard.action, Keyword.merge(var_params, time_range_params))
+  end
 
   @doc """
   return the dashboard's default time range

--- a/lib/luminous/dashboard.ex
+++ b/lib/luminous/dashboard.ex
@@ -21,7 +21,6 @@ defmodule Luminous.Dashboard do
           panels: [Panel.t()],
           variables: [Variable.t()],
           time_range_selector: TimeRangeSelector.t(),
-          time_range_presets: [%{label: binary(), value: TimeRange.t()}],
           time_zone: binary()
         }
 
@@ -34,7 +33,6 @@ defmodule Luminous.Dashboard do
     :panels,
     :variables,
     :time_range_selector,
-    :time_range_presets,
     :time_zone
   ]
 
@@ -50,7 +48,6 @@ defmodule Luminous.Dashboard do
       time_range_selector: time_range_selector,
       panels: Keyword.get(opts, :panels, []),
       variables: Keyword.get(opts, :variables, []),
-      time_range_presets: [],
       time_zone: Keyword.get(opts, :time_zone, @default_time_zone)
     }
   end
@@ -62,7 +59,6 @@ defmodule Luminous.Dashboard do
   def populate(dashboard) do
     dashboard
     |> Map.put(:variables, Enum.map(dashboard.variables, &Variable.populate/1))
-    |> Map.put(:time_range_presets, default_presets(dashboard))
     |> Map.put(
       :time_range_selector,
       TimeRangeSelector.populate(dashboard.time_range_selector, dashboard.time_zone)
@@ -101,42 +97,5 @@ defmodule Luminous.Dashboard do
       | time_range_selector:
           TimeRangeSelector.update_current(dashboard.time_range_selector, time_range)
     }
-  end
-
-  defp default_presets(dashboard) do
-    [
-      %{
-        label: "Default",
-        value: default_time_range(dashboard)
-      },
-      %{
-        label: "Today",
-        value: TimeRange.today(dashboard.time_zone)
-      },
-      %{
-        label: "Yesterday",
-        value: TimeRange.yesterday(dashboard.time_zone)
-      },
-      %{
-        label: "Last 7 days",
-        value: TimeRange.last_n_days(7, dashboard.time_zone)
-      },
-      %{
-        label: "This week",
-        value: TimeRange.this_week(dashboard.time_zone)
-      },
-      %{
-        label: "Previous week",
-        value: TimeRange.last_week(dashboard.time_zone)
-      },
-      %{
-        label: "This month",
-        value: TimeRange.this_month(dashboard.time_zone)
-      },
-      %{
-        label: "Previous month",
-        value: TimeRange.last_month(dashboard.time_zone)
-      }
-    ]
   end
 end

--- a/lib/luminous/live.ex
+++ b/lib/luminous/live.ex
@@ -76,6 +76,30 @@ defmodule Luminous.Live do
       end
 
       @impl true
+      def handle_event(
+            "preset_time_range_selected",
+            %{"preset" => preset},
+            %{assigns: %{dashboard: dashboard}} = socket
+          ) do
+        time_range =
+          TimeRangeSelector.get_time_range_for(
+            dashboard.time_range_selector,
+            preset,
+            dashboard.time_zone
+          )
+
+        url_params =
+          dashboard.variables
+          |> Enum.map(&{&1.id, &1.current.value})
+          |> Keyword.merge(
+            from: DateTime.to_unix(time_range.from),
+            to: DateTime.to_unix(time_range.to)
+          )
+
+        {:noreply, push_patch(socket, to: Dashboard.path(dashboard, socket, url_params))}
+      end
+
+      @impl true
       def handle_info({_task_ref, {%Panel{type: :chart} = panel, datasets}}, socket) do
         datasets = Enum.map(datasets, &Query.DataSet.maybe_override_unit(&1, panel.unit))
 

--- a/lib/luminous/variable.ex
+++ b/lib/luminous/variable.ex
@@ -42,6 +42,12 @@ defmodule Luminous.Variable do
   """
   @spec define(atom(), binary(), module()) :: t()
   def define(id, label, mod) do
+    if id in [:from, :to] do
+      raise ArgumentError,
+        message:
+          ":from and :to are reserved atoms in luminous and can not be used as variable IDs"
+    end
+
     %__MODULE__{
       id: id,
       label: label,

--- a/test/luminous/live_test.exs
+++ b/test/luminous/live_test.exs
@@ -96,6 +96,29 @@ defmodule Luminous.LiveTest do
       refute has_element?(view, "#panel-p3-stat-values", "0")
       assert has_element?(view, "#panel-p3-stat-values", "666")
     end
+
+    test "when a time range preset is selected", %{conn: conn} do
+      {:ok, view, _} = live(conn, Routes.test_dashboard_path(conn, :index))
+
+      view
+      |> element("#time-range-preset-Yesterday")
+      |> render_click()
+
+      # we use "Europe/Athens" because this is the time zone defined in TestDashboardLive module
+      yesterday = DateTime.now!("Europe/Athens") |> DateTime.to_date() |> Date.add(-1)
+
+      from =
+        yesterday
+        |> DateTime.new!(~T[00:00:00], "Europe/Athens")
+        |> DateTime.to_unix()
+
+      to = DateTime.new!(yesterday, ~T[23:59:59], "Europe/Athens") |> DateTime.to_unix()
+
+      assert_patched(
+        view,
+        Routes.test_dashboard_path(conn, :index, var1: "a", var2: 1, from: from, to: to)
+      )
+    end
   end
 
   describe "variables" do

--- a/test/luminous/live_test.exs
+++ b/test/luminous/live_test.exs
@@ -128,5 +128,36 @@ defmodule Luminous.LiveTest do
       assert has_element?(view, "#var1-dropdown li", "a")
       assert has_element?(view, "#var2-dropdown li", "1")
     end
+
+    test "when a variable value is selected", %{conn: conn} do
+      {:ok, view, _} = live(conn, Routes.test_dashboard_path(conn, :index))
+
+      view |> element("#var1-b") |> render_click()
+
+      # we use "Europe/Athens" because this is the time zone defined in TestDashboardLive module
+      tr = Luminous.TimeRange.yesterday("Europe/Athens")
+
+      assert_patched(
+        view,
+        Routes.test_dashboard_path(conn, :index,
+          var1: "b",
+          var2: 1,
+          from: DateTime.to_unix(tr.from),
+          to: DateTime.to_unix(tr.to)
+        )
+      )
+
+      view |> element("#var2-3") |> render_click()
+
+      assert_patched(
+        view,
+        Routes.test_dashboard_path(conn, :index,
+          var2: 3,
+          var1: "b",
+          from: DateTime.to_unix(tr.from),
+          to: DateTime.to_unix(tr.to)
+        )
+      )
+    end
   end
 end

--- a/test/luminous/live_test.exs
+++ b/test/luminous/live_test.exs
@@ -152,8 +152,8 @@ defmodule Luminous.LiveTest do
       assert_patched(
         view,
         Routes.test_dashboard_path(conn, :index,
-          var2: 3,
           var1: "b",
+          var2: 3,
           from: DateTime.to_unix(tr.from),
           to: DateTime.to_unix(tr.to)
         )


### PR DESCRIPTION
Until now the time range presets' values were resolved when the page was loaded. This resulted in a strange behavior: if the page was loaded at some point during a day and the user eventually clicked a preset on the next day, the page rendered the results of an incorrect time range (off by 1 day). This commit fixes this issue. In addition, the responsibility of calculating the time ranges for each preset is moved from `Dashboard` to `TimeRangeSelector` module.

Furthermore, I refactored the page rendering when new variable values are selected, which resulted in simpler code.