### PR TITLE
Pass socket assigns to `Luminous.Variable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ grafana both conceptually and functionally in that:
 - it can be parameterized by user-defined variables
 
 Dashboards are defined at compile time using elixir code (see
-`Luminous.Dashboard.define/4`). At runtime, Luminous uses the
+`Luminous.Dashboard.define/3`). At runtime, Luminous uses the
 following javascript libraries (as [live view
 hooks](https://hexdocs.pm/phoenix_live_view/js-interop.html#client-hooks-via-phx-hook))
 for supporting client-side visualizations and interactions with the
@@ -94,8 +94,10 @@ In general, a custom dashboard needs to:
   dashboard-specific variables
 - implement the `Luminous.Query` behaviour for loading the necessary
   data that will be visualized in the client
-- implement the `Luminous.TimeRangeSelector` behaviour for determining
-  the default time range for the dashboard
+- implement the `Luminous.Dashboard` behaviour for determining
+  the default time range for the dashboard and optionally injecting
+  parameters to `Luminous.Variable.variable/2` callbacks
+  (see `Luminous.Dashboard.parameters/1`)
 - `use` the `Luminous.Live` module for leveraging the live dashboard
   functionality and capabilities
 - render the dashboard in the view template (only

--- a/assets/js/components/chartjs_hook.js
+++ b/assets/js/components/chartjs_hook.js
@@ -334,6 +334,14 @@ function ChartJSHook() {
       })
       this.chart.data = { datasets: datasets }
 
+      // This prevents the first and the last bars in a bar chart
+      // to be cut in half. Even though the `offset` option is set
+      // to `true` by default for bar charts, the initial value is
+      // `false` because the chart's is declared as `line`.
+      if (Array.isArray(datasets) && datasets.length > 0 && datasets[0].type === "bar") {
+        this.chart.options.scales.x.offset = true
+      }
+
       // set time zone
       this.chart.options.scales.x.adapters.date.zone = payload.time_zone
 

--- a/assets/js/components/chartjs_hook.js
+++ b/assets/js/components/chartjs_hook.js
@@ -2,7 +2,7 @@ import { Chart, registerables, Tooltip } from 'chart.js'
 import { DateTime } from 'luxon'
 import "chartjs-adapter-luxon"
 import zoomPlugin from 'chartjs-plugin-zoom';
-import {sendFileToClient} from './utils'
+import { sendFileToClient } from './utils'
 
 let colors = ["#fd7f6f", "#7eb0d5", "#b2e061", "#bd7ebe", "#ffb55a", "#ffee65", "#beb9db", "#fdcce5", "#8bd3c7"]
 
@@ -340,6 +340,10 @@ function ChartJSHook() {
       // display ylabel
       this.chart.options.scales.y.title.display = true
       this.chart.options.scales.y.title.text = payload.ylabel
+
+      // set min and max values of Y axis
+      this.chart.options.scales.y.suggestedMin = payload.y_min_value
+      this.chart.options.scales.y.suggestedMax = payload.y_max_value
 
       // toggle stacking
       this.chart.options.scales.y.stacked = payload.stacked_x

--- a/dev/demo_dashboard_live.ex
+++ b/dev/demo_dashboard_live.ex
@@ -19,7 +19,6 @@ defmodule Luminous.Dashboards.DemoDashboardLive do
       Dashboard.define(
         "Demo Dashboard",
         {&Routes.demo_dashboard_path/3, :index},
-        TimeRangeSelector.define(__MODULE__),
         panels: [
           Panel.define(
             :simple_time_series,
@@ -95,7 +94,6 @@ defmodule Luminous.Dashboards.DemoDashboardLive do
   end
 
   # a live dashboard also needs to specify its default time range
-  @behaviour TimeRangeSelector
   @impl true
   def default_time_range(tz), do: TimeRange.last_n_days(7, tz)
 

--- a/dev/test_dashboard_live.ex
+++ b/dev/test_dashboard_live.ex
@@ -10,7 +10,6 @@ defmodule Luminous.Dashboards.TestDashboardLive do
       Dashboard.define(
         "Test Dashboard",
         {&Routes.test_dashboard_path/3, :index},
-        TimeRangeSelector.define(__MODULE__),
         panels: [
           Panel.define(
             :p1,
@@ -93,7 +92,6 @@ defmodule Luminous.Dashboards.TestDashboardLive do
     %{test_param: ["test_param_val_1", "test_param_val_2"]}
   end
 
-  @behaviour TimeRangeSelector
   @impl true
   def default_time_range(tz), do: TimeRange.yesterday(tz)
 

--- a/dev/test_dashboard_live.ex
+++ b/dev/test_dashboard_live.ex
@@ -3,14 +3,108 @@ defmodule Luminous.Dashboards.TestDashboardLive do
 
   alias Luminous.Router.Helpers, as: Routes
   alias Luminous.{Variable, Query, Dashboard, TimeRange, Components}
+  alias Luminous.Dashboards.TestDashboardLive.{Queries, Variables}
+
+  use Luminous.Live,
+    dashboard:
+      Dashboard.define(
+        "Test Dashboard",
+        {&Routes.test_dashboard_path/3, :index},
+        TimeRangeSelector.define(__MODULE__),
+        panels: [
+          Panel.define(
+            :p1,
+            "Panel 1",
+            :chart,
+            [Query.define(:q1, Queries)],
+            ylabel: "Foo (μCKR)"
+          ),
+          Panel.define(
+            :p2,
+            "Panel 2",
+            :stat,
+            [Query.define(:q2, Queries)]
+          ),
+          Panel.define(
+            :p3,
+            "Panel 3",
+            :stat,
+            [Query.define(:q3, Queries)]
+          ),
+          Panel.define(
+            :p4,
+            "Panel 4",
+            :stat,
+            [Query.define(:q4, Queries)]
+          ),
+          Panel.define(
+            :p5,
+            "Panel 5",
+            :stat,
+            [Query.define(:q5, Queries)]
+          ),
+          Panel.define(
+            :p6,
+            "Panel 6",
+            :stat,
+            [Query.define(:q6, Queries)]
+          ),
+          Panel.define(
+            :p7,
+            "Panel 7 (table)",
+            :table,
+            [Query.define(:q7, Queries)]
+          ),
+          Panel.define(
+            :p8,
+            "Panel 8 (stat with simple value)",
+            :stat,
+            [Query.define(:q8, Queries)]
+          ),
+          Panel.define(
+            :p9,
+            "Panel 9 (empty stat)",
+            :stat,
+            [Query.define(:q9, Queries)]
+          ),
+          Panel.define(
+            :p10,
+            "Panel 10 (stats as list of 2-tuples)",
+            :stat,
+            [Query.define(:q10, Queries)]
+          ),
+          Panel.define(
+            :p11,
+            "Panel 11 (nil stat)",
+            :stat,
+            [Query.define(:q11, Queries)]
+          )
+        ],
+        variables: [
+          Variable.define(:var1, "Var 1", Variables),
+          Variable.define(:var2, "Var 2", Variables),
+          Variable.define(:var3, "Var 3", Variables)
+        ],
+        time_zone: "Europe/Athens"
+      )
+
+  @impl true
+  def parameters(_socket) do
+    %{test_param: ["test_param_val_1", "test_param_val_2"]}
+  end
+
+  @behaviour TimeRangeSelector
+  @impl true
+  def default_time_range(tz), do: TimeRange.yesterday(tz)
 
   defmodule Variables do
     @moduledoc false
 
     @behaviour Variable
     @impl true
-    def variable(:var1), do: ["a", "b", "c"]
-    def variable(:var2), do: ["1", "2", "3"]
+    def variable(:var1, _), do: ["a", "b", "c"]
+    def variable(:var2, _), do: ["1", "2", "3"]
+    def variable(:var3, %{test_param: values}), do: values
   end
 
   defmodule Queries do
@@ -106,92 +200,6 @@ defmodule Luminous.Dashboards.TestDashboardLive do
       Query.Result.new([{"foo", nil}])
     end
   end
-
-  use Luminous.Live,
-    dashboard:
-      Dashboard.define(
-        "Test Dashboard",
-        {&Routes.test_dashboard_path/3, :index},
-        TimeRangeSelector.define(__MODULE__),
-        panels: [
-          Panel.define(
-            :p1,
-            "Panel 1",
-            :chart,
-            [Query.define(:q1, Queries)],
-            ylabel: "Foo (μCKR)"
-          ),
-          Panel.define(
-            :p2,
-            "Panel 2",
-            :stat,
-            [Query.define(:q2, Queries)]
-          ),
-          Panel.define(
-            :p3,
-            "Panel 3",
-            :stat,
-            [Query.define(:q3, Queries)]
-          ),
-          Panel.define(
-            :p4,
-            "Panel 4",
-            :stat,
-            [Query.define(:q4, Queries)]
-          ),
-          Panel.define(
-            :p5,
-            "Panel 5",
-            :stat,
-            [Query.define(:q5, Queries)]
-          ),
-          Panel.define(
-            :p6,
-            "Panel 6",
-            :stat,
-            [Query.define(:q6, Queries)]
-          ),
-          Panel.define(
-            :p7,
-            "Panel 7 (table)",
-            :table,
-            [Query.define(:q7, Queries)]
-          ),
-          Panel.define(
-            :p8,
-            "Panel 8 (stat with simple value)",
-            :stat,
-            [Query.define(:q8, Queries)]
-          ),
-          Panel.define(
-            :p9,
-            "Panel 9 (empty stat)",
-            :stat,
-            [Query.define(:q9, Queries)]
-          ),
-          Panel.define(
-            :p10,
-            "Panel 10 (stats as list of 2-tuples)",
-            :stat,
-            [Query.define(:q10, Queries)]
-          ),
-          Panel.define(
-            :p11,
-            "Panel 11 (nil stat)",
-            :stat,
-            [Query.define(:q11, Queries)]
-          )
-        ],
-        variables: [
-          Variable.define(:var1, "Var 1", Variables),
-          Variable.define(:var2, "Var 2", Variables)
-        ],
-        time_zone: "Europe/Athens"
-      )
-
-  @behaviour TimeRangeSelector
-  @impl true
-  def default_time_range(tz), do: TimeRange.yesterday(tz)
 
   def render(assigns) do
     ~H"""

--- a/dist/luminous.js
+++ b/dist/luminous.js
@@ -19670,6 +19670,9 @@ function ChartJSHook() {
         };
       });
       this.chart.data = { datasets };
+      if (Array.isArray(datasets) && datasets.length > 0 && datasets[0].type === "bar") {
+        this.chart.options.scales.x.offset = true;
+      }
       this.chart.options.scales.x.adapters.date.zone = payload.time_zone;
       this.chart.options.scales.y.title.display = true;
       this.chart.options.scales.y.title.text = payload.ylabel;

--- a/dist/luminous.js
+++ b/dist/luminous.js
@@ -19673,6 +19673,8 @@ function ChartJSHook() {
       this.chart.options.scales.x.adapters.date.zone = payload.time_zone;
       this.chart.options.scales.y.title.display = true;
       this.chart.options.scales.y.title.text = payload.ylabel;
+      this.chart.options.scales.y.suggestedMin = payload.y_min_value;
+      this.chart.options.scales.y.suggestedMax = payload.y_max_value;
       this.chart.options.scales.y.stacked = payload.stacked_x;
       this.chart.options.scales.x.stacked = payload.stacked_y;
       this.chart.options.scales.y.grid.display = n > 0;

--- a/lib/luminous/components.ex
+++ b/lib/luminous/components.ex
@@ -238,8 +238,8 @@ defmodule Luminous.Components do
       <div class="lmn-time-range-compound">
         <div class="lmn-time-range-selector">
           <!-- Date picker -->
-          <input id={@dashboard.time_range_selector.id}
-            phx-hook={@dashboard.time_range_selector.hook}
+          <input id={TimeRangeSelector.id()}
+            phx-hook={TimeRangeSelector.hook()}
             phx-update="ignore" readonly="readonly"
             class="lmn-custom-time-range-input" />
           <!-- Presets button & dropdown -->

--- a/lib/luminous/dashboard.ex
+++ b/lib/luminous/dashboard.ex
@@ -6,6 +6,14 @@ defmodule Luminous.Dashboard do
   compile time using `define/4` and populated at runtime using `populate/1`.
   """
 
+  @doc """
+  The consumer can optionally implement this callback, in case they want to
+  inject custom parameters in other callbacks (e.g. `Luminous.Variable.variable/2`).
+  Those parameters can be used to scope the callback results.
+  """
+  @callback parameters(Phoenix.LiveView.Socket.t()) :: map()
+  @optional_callbacks parameters: 1
+
   alias Luminous.{Panel, TimeRange, TimeRangeSelector, Variable}
 
   @default_time_zone "Europe/Athens"
@@ -51,10 +59,10 @@ defmodule Luminous.Dashboard do
   @doc """
   Populate the dashboard's dynamic properties (e.g. variable values, time range etc.) at runtime.
   """
-  @spec populate(t()) :: t()
-  def populate(dashboard) do
+  @spec populate(t(), map()) :: t()
+  def populate(dashboard, params) do
     dashboard
-    |> Map.put(:variables, Enum.map(dashboard.variables, &Variable.populate/1))
+    |> Map.put(:variables, Enum.map(dashboard.variables, &Variable.populate(&1, params)))
     |> Map.put(
       :time_range_selector,
       TimeRangeSelector.populate(dashboard.time_range_selector, dashboard.time_zone)

--- a/lib/luminous/live.ex
+++ b/lib/luminous/live.ex
@@ -79,7 +79,7 @@ defmodule Luminous.Live do
           socket =
             socket
             |> assign(dashboard: dashboard)
-            |> push_time_range_event(dashboard.time_range_selector.id, time_range)
+            |> push_time_range_event(TimeRangeSelector.id(), time_range)
 
           {:noreply, socket}
         else
@@ -109,11 +109,10 @@ defmodule Luminous.Live do
             %{assigns: %{dashboard: dashboard}} = socket
           ) do
         time_range =
-          TimeRangeSelector.get_time_range_for(
-            dashboard.time_range_selector,
-            preset,
-            dashboard.time_zone
-          )
+          case TimeRangeSelector.get_time_range_for(preset, dashboard.time_zone) do
+            nil -> default_time_range(dashboard.time_zone)
+            time_range -> time_range
+          end
 
         {:noreply,
          push_patch(socket,
@@ -189,7 +188,7 @@ defmodule Luminous.Live do
         |> TimeRange.shift_zone!(dashboard.time_zone)
       end
 
-      defp get_time_range(dashboard, _), do: Dashboard.default_time_range(dashboard)
+      defp get_time_range(dashboard, _), do: default_time_range(dashboard.time_zone)
 
       defp push_panel_load_event(socket, :start, panel_id),
         do: push_event(socket, "panel:load:start", %{id: panel_id})

--- a/lib/luminous/live.ex
+++ b/lib/luminous/live.ex
@@ -140,6 +140,8 @@ defmodule Luminous.Live do
           xlabel: panel.xlabel,
           stacked_x: panel.stacked_x,
           stacked_y: panel.stacked_y,
+          y_min_value: panel.y_min_value,
+          y_max_value: panel.y_max_value,
           time_zone: socket.assigns.dashboard.time_zone
         }
 

--- a/lib/luminous/live.ex
+++ b/lib/luminous/live.ex
@@ -8,6 +8,8 @@ defmodule Luminous.Live do
     quote do
       use Phoenix.LiveView
 
+      @behaviour Luminous.Dashboard
+
       alias Luminous.{
         Dashboard,
         Components,
@@ -24,7 +26,14 @@ defmodule Luminous.Live do
 
       @impl true
       def mount(_, _, socket) do
-        dashboard = Dashboard.populate(unquote(dashboard))
+        params =
+          if function_exported?(__MODULE__, :parameters, 1) do
+            apply(__MODULE__, :parameters, [socket])
+          else
+            %{}
+          end
+
+        dashboard = Dashboard.populate(dashboard(), params)
 
         {:ok,
          assign(socket,

--- a/lib/luminous/panel.ex
+++ b/lib/luminous/panel.ex
@@ -32,7 +32,9 @@ defmodule Luminous.Panel do
           xlabel: binary(),
           stacked_x: boolean(),
           stacked_y: boolean(),
-          hook: binary()
+          hook: binary(),
+          y_min_value: number(),
+          y_max_value: number()
         }
 
   @enforce_keys [:id, :title, :type, :queries, :hook]
@@ -47,7 +49,9 @@ defmodule Luminous.Panel do
     :ylabel,
     :xlabel,
     :stacked_x,
-    :stacked_y
+    :stacked_y,
+    :y_min_value,
+    :y_max_value
   ]
 
   @doc """
@@ -68,7 +72,9 @@ defmodule Luminous.Panel do
       stacked_x:
         if(Keyword.has_key?(opts, :stacked_x), do: Keyword.get(opts, :stacked_x), else: false),
       stacked_y:
-        if(Keyword.has_key?(opts, :stacked_y), do: Keyword.get(opts, :stacked_y), else: false)
+        if(Keyword.has_key?(opts, :stacked_y), do: Keyword.get(opts, :stacked_y), else: false),
+      y_min_value: Keyword.get(opts, :y_min_value),
+      y_max_value: Keyword.get(opts, :y_max_value)
     }
   end
 

--- a/lib/luminous/variable.ex
+++ b/lib/luminous/variable.ex
@@ -8,7 +8,7 @@ defmodule Luminous.Variable do
   @doc """
   A module must implement this behaviour to be passed as an argument to `define/3`.
   """
-  @callback variable(atom()) :: [simple_value() | descriptive_value()]
+  @callback variable(atom(), map()) :: [simple_value() | descriptive_value()]
 
   @type simple_value :: binary()
   @type descriptive_value :: %{label: binary(), value: binary()}
@@ -55,11 +55,11 @@ defmodule Luminous.Variable do
   Uses the query to populate the variables's values and returns the new struct.
   Additionally, it sets the current value to be the first of the calculated values.
   """
-  @spec populate(t()) :: t()
-  def populate(var) do
+  @spec populate(t(), map()) :: t()
+  def populate(var, params) do
     values =
       var.mod
-      |> apply(:variable, [var.id])
+      |> apply(:variable, [var.id, params])
       |> Enum.map(fn
         m when is_map(m) -> m
         s when is_binary(s) -> %{label: s, value: s}

--- a/test/luminous/live_test.exs
+++ b/test/luminous/live_test.exs
@@ -62,7 +62,9 @@ defmodule Luminous.LiveTest do
         stacked_y: false,
         time_zone: "Europe/Athens",
         xlabel: nil,
-        ylabel: "Foo (μCKR)"
+        ylabel: "Foo (μCKR)",
+        y_min_value: nil,
+        y_max_value: nil
       }
 
       assert_push_event(view, "panel-p1::refresh-data", ^expected_data)

--- a/test/luminous/live_test.exs
+++ b/test/luminous/live_test.exs
@@ -179,7 +179,13 @@ defmodule Luminous.LiveTest do
 
       assert_patched(
         view,
-        Routes.test_dashboard_path(conn, :index, var1: "a", var2: 1, from: from, to: to)
+        Routes.test_dashboard_path(conn, :index,
+          var1: "a",
+          var2: 1,
+          var3: "test_param_val_1",
+          from: from,
+          to: to
+        )
       )
     end
   end
@@ -205,6 +211,7 @@ defmodule Luminous.LiveTest do
         Routes.test_dashboard_path(conn, :index,
           var1: "b",
           var2: 1,
+          var3: "test_param_val_1",
           from: DateTime.to_unix(tr.from),
           to: DateTime.to_unix(tr.to)
         )
@@ -217,10 +224,18 @@ defmodule Luminous.LiveTest do
         Routes.test_dashboard_path(conn, :index,
           var1: "b",
           var2: 3,
+          var3: "test_param_val_1",
           from: DateTime.to_unix(tr.from),
           to: DateTime.to_unix(tr.to)
         )
       )
+    end
+
+    test "when a variable requires a param from the LV socket", %{conn: conn} do
+      {:ok, view, _} = live(conn, Routes.test_dashboard_path(conn, :index))
+
+      assert has_element?(view, "#var3-dropdown li", "test_param_val_1")
+      assert has_element?(view, "#var3-dropdown li", "test_param_val_2")
     end
   end
 end


### PR DESCRIPTION
In some cases, the consumer needs to use values stored in socket assigns in order to populate the variable values by implementing the `Luminous.Variable.variable/1` callback. 

In order to achieve that, I added the argument `required_assign_variables`, which is by default an empty list, to allow the consumer to define the name of the variables they need from socket assigns. The values of the defined variables are then extracted from socket assigns and passed as a second argument to the `Luminous.Variable.variable/2` callback, thus making the socket assigns variables accessible to the consumer. If the socket assigns variable does not exist, then the value of the variable in the passed map is `nil`.