### PR TITLE
Improve tooltip css

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The package can be installed from `hex.pm` as follows:
 ```elixir
 def deps do
   [
-    {:luminous, "~> 1.3.1"}
+    {:luminous, "~> 1.3.2"}
   ]
 end
 ```

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -99,4 +99,12 @@
 	.lmn-dropdown-transition-end {
 		@apply opacity-100 scale-100
 	}
+
+	.lmn-tooltip {
+		@apply absolute invisible md:w-64 rounded-md p-2 text-sm bg-gray-800 text-gray-100 opacity-0 transition-opacity;
+	}
+
+	.lmn-has-tooltip:hover .lmn-tooltip {
+		@apply visible z-50 opacity-100
+	}
 }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "luminous",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "luminous",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "devDependencies": {
         "chart.js": "^3.3.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luminous",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "The JavaScript client for the Luminous framework.",
   "license": "MIT",
   "main": "./assets/js/app.js",

--- a/dist/luminous.css
+++ b/dist/luminous.css
@@ -1748,6 +1748,33 @@ video {
   opacity: 1;
 }
 
+.lmn-tooltip {
+  visibility: hidden;
+  position: absolute;
+  border-radius: 0.375rem;
+  background-color: #1f2937;
+  padding: 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: #f3f4f6;
+  opacity: 0;
+  transition-property: opacity;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+@media (min-width: 768px) {
+  .lmn-tooltip {
+    width: 16rem;
+  }
+}
+
+.lmn-has-tooltip:hover .lmn-tooltip {
+  visibility: visible;
+  z-index: 50;
+  opacity: 1;
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -1788,10 +1815,6 @@ video {
   top: 2.5rem;
 }
 
-.left-1\/2 {
-  left: 50%;
-}
-
 .z-10 {
   z-index: 10;
 }
@@ -1802,10 +1825,6 @@ video {
 
 .col-span-5 {
   grid-column: span 5 / span 5;
-}
-
-.m-4 {
-  margin: 1rem;
 }
 
 .mx-8 {
@@ -1873,13 +1892,8 @@ video {
   max-width: 1024px;
 }
 
-.-translate-x-1\/2 {
-  --tw-translate-x: -50%;
-  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
-}
-
-.translate-y-2 {
-  --tw-translate-y: 0.5rem;
+.translate-y-6 {
+  --tw-translate-y: 1.5rem;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
@@ -1972,24 +1986,12 @@ video {
   white-space: nowrap;
 }
 
-.rounded-md {
-  border-radius: 0.375rem;
-}
-
 .bg-white {
   background-color: #fff;
 }
 
-.bg-gray-800 {
-  background-color: #1f2937;
-}
-
 .fill-blue-600 {
   fill: #2563eb;
-}
-
-.p-2 {
-  padding: 0.5rem;
 }
 
 .py-4 {
@@ -2044,11 +2046,6 @@ video {
   line-height: 1rem;
 }
 
-.text-sm {
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-}
-
 .font-bold {
   font-weight: 700;
 }
@@ -2065,16 +2062,8 @@ video {
   color: #e5e7eb;
 }
 
-.text-gray-100 {
-  color: #f3f4f6;
-}
-
 .opacity-100 {
   opacity: 1;
-}
-
-.opacity-0 {
-  opacity: 0;
 }
 
 .shadow-lg {
@@ -2093,12 +2082,6 @@ video {
   --tw-backdrop-grayscale: grayscale(100%);
   -webkit-backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
           backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
-}
-
-.transition-opacity {
-  transition-property: opacity;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
 }
 
 .transition {
@@ -3422,10 +3405,6 @@ body.tabulator-print-fullscreen-hide>:not(.tabulator-print-fullscreen){
   outline-offset: 2px;
 }
 
-.group:hover .group-hover\:opacity-100 {
-  opacity: 1;
-}
-
 @media (prefers-color-scheme: dark) {
   .dark\:text-gray-600 {
     color: #4b5563;
@@ -3433,10 +3412,6 @@ body.tabulator-print-fullscreen-hide>:not(.tabulator-print-fullscreen){
 }
 
 @media (min-width: 768px) {
-  .md\:w-64 {
-    width: 16rem;
-  }
-
   .md\:flex-row {
     flex-direction: row;
   }

--- a/lib/luminous/components.ex
+++ b/lib/luminous/components.ex
@@ -354,11 +354,13 @@ defmodule Luminous.Components do
 
   def description(assigns) do
     ~H"""
-    <div class="group flex relative">
-      <div id={"lum-#{@panel.id}-tooltip"} class="z-10 md:w-64 group-hover:opacity-100 transition-opacity bg-gray-800 p-2 m-4 opacity-0 text-sm text-gray-100 rounded-md absolute left-1/2 -translate-x-1/2 translate-y-2"><span><%= @panel.description %></span></div>
+    <div class="flex flex-col items-center lmn-has-tooltip">
       <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
       </svg>
+      <div id={"lum-#{@panel.id}-tooltip"} class="lmn-tooltip translate-y-6">
+        <%= @panel.description %>
+      </div>
     </div>
     """
   end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Luminous.MixProject do
   def project do
     [
       app: :luminous,
-      version: "1.3.1",
+      version: "1.3.2",
       elixir: ">= 1.12.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "luminous",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "The JavaScript client for the Luminous framework.",
 	"license": "MIT",
 	"module": "./dist/luminous.js",


### PR DESCRIPTION
The existing tooltip implementation is buggy. The tooltip is displayed even when the cursor is hovering the tooltip's body and not the respective element.

This patch fixes the aforementioned issue and introduces two new CSS classes that could be used to easier add tooltips where needed.