### PR TITLE
Fix for the dropdown bug

### DIFF
--- a/assets/js/components/utils.js
+++ b/assets/js/components/utils.js
@@ -3,6 +3,7 @@ export function sendFileToClient(url, filename) {
   link.setAttribute("href", url);
   link.setAttribute("download", filename);
   link.style.visibility = 'hidden';
+  link.setAttribute("target", "_blank")
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);


### PR DESCRIPTION
To replicate the bug, you need to press `Download CSV` or `Download PNG` in the dashboard dropdown, and this would cause the phoenix socket to disconnect, causing the vast majority of dropdowns and other functionality to stop working. I replicated this in the dev environment by running `mix dev`. 

There is a similar problem was discussed in this [issue](https://github.com/phoenixframework/phoenix_live_view/issues/2552). It is about LiveView disconnecting when a download link is pressed, which is exactly what is happening here.

To fix the problem, the link that was clicked in `utils.js` with `link.click();` should not redirect, by having `target` set to `_blank`.