### PR TITLE
Add totals option to table panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The package can be installed from `hex.pm` as follows:
 ```elixir
 def deps do
   [
-    {:luminous, "~> 1.3.3"}
+    {:luminous, "~> 1.4.0"}
   ]
 end
 ```

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "luminous",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "luminous",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "chart.js": "^3.3.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luminous",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "The JavaScript client for the Luminous framework.",
   "license": "MIT",
   "main": "./assets/js/app.js",

--- a/dev/demo_dashboard_live.ex
+++ b/dev/demo_dashboard_live.ex
@@ -283,8 +283,10 @@ defmodule Luminous.Dashboards.DemoDashboardLive do
         data,
         attrs: %{
           "label" => Query.Attributes.define(title: "Label", order: 0, halign: :center),
-          "foo" => Query.Attributes.define(title: "Foo", order: 1, halign: :right),
-          "bar" => Query.Attributes.define(title: "Bar", order: 2, halign: :right)
+          "foo" =>
+            Query.Attributes.define(title: "Foo", order: 1, halign: :right, table_totals: :sum),
+          "bar" =>
+            Query.Attributes.define(title: "Bar", order: 2, halign: :right, table_totals: :avg)
         }
       )
     end

--- a/dev/test_dashboard_live.ex
+++ b/dev/test_dashboard_live.ex
@@ -167,8 +167,10 @@ defmodule Luminous.Dashboards.TestDashboardLive do
         ],
         attrs: %{
           "label" => Query.Attributes.define(title: "Label", order: 0, halign: :center),
-          "foo" => Query.Attributes.define(title: "Foo", order: 1, halign: :right),
-          "bar" => Query.Attributes.define(title: "Bar", order: 2, halign: :right)
+          "foo" =>
+            Query.Attributes.define(title: "Foo", order: 1, halign: :right, table_totals: :sum),
+          "bar" =>
+            Query.Attributes.define(title: "Bar", order: 2, halign: :right, table_totals: :avg)
         }
       )
     end

--- a/lib/luminous/panel/table.ex
+++ b/lib/luminous/panel/table.ex
@@ -12,7 +12,8 @@ defmodule Luminous.Panel.Table do
           field: label,
           title: attr.title || label,
           hozAlign: attr.halign,
-          headerHozAlign: attr.halign
+          headerHozAlign: attr.halign,
+          bottomCalc: attr.table_totals
         }
       end)
 

--- a/lib/luminous/query.ex
+++ b/lib/luminous/query.ex
@@ -17,11 +17,12 @@ defmodule Luminous.Query do
             fill: boolean(),
             unit: binary(),
             title: binary(),
-            halign: :left | :center | :right
+            halign: :left | :center | :right,
+            table_totals: :sum | :avg | :min | :max | :count
           }
 
     @derive Jason.Encoder
-    defstruct [:type, :order, :fill, :unit, :title, :halign]
+    defstruct [:type, :order, :fill, :unit, :title, :halign, :table_totals]
 
     @spec define(Keyword.t()) :: t()
     def define(opts) do
@@ -35,7 +36,8 @@ defmodule Luminous.Query do
           ),
         unit: Keyword.get(opts, :unit),
         title: Keyword.get(opts, :title),
-        halign: Keyword.get(opts, :halign, :left)
+        halign: Keyword.get(opts, :halign, :left),
+        table_totals: Keyword.get(opts, :table_totals)
       }
     end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Luminous.MixProject do
   def project do
     [
       app: :luminous,
-      version: "1.3.3",
+      version: "1.4.0",
       elixir: ">= 1.12.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "luminous",
-	"version": "1.3.3",
+	"version": "1.4.0",
 	"description": "The JavaScript client for the Luminous framework.",
 	"license": "MIT",
 	"module": "./dist/luminous.js",

--- a/test/luminous/live_test.exs
+++ b/test/luminous/live_test.exs
@@ -114,9 +114,27 @@ defmodule Luminous.LiveTest do
 
       expected_data = %{
         columns: [
-          %{field: "label", headerHozAlign: :center, hozAlign: :center, title: "Label"},
-          %{field: "foo", headerHozAlign: :right, hozAlign: :right, title: "Foo"},
-          %{field: "bar", headerHozAlign: :right, hozAlign: :right, title: "Bar"}
+          %{
+            field: "label",
+            headerHozAlign: :center,
+            hozAlign: :center,
+            title: "Label",
+            bottomCalc: nil
+          },
+          %{
+            field: "foo",
+            headerHozAlign: :right,
+            hozAlign: :right,
+            title: "Foo",
+            bottomCalc: :sum
+          },
+          %{
+            field: "bar",
+            headerHozAlign: :right,
+            hozAlign: :right,
+            title: "Bar",
+            bottomCalc: :avg
+          }
         ],
         rows: [
           %{"bar" => 88, "foo" => 3, "label" => "row1"},


### PR DESCRIPTION
`tabulator` has a [feature](https://tabulator.info/docs/5.4/column-calcs#func-builtin) that adds an extra row to the table, the cells of which contain the result of a builtin (basic) function like sum, average, min, max and others. With this change, `luminous` gives its consumers access to that feature. The consumer can now specify one of the following calculation functions:
- `:sum` 
- `:avg` 
- `:min`
- `:max`

to be applied to the column values and be displayed to an extra table row like so:
![image](https://github.com/elinverd/luminous/assets/951049/1943e24a-897a-4671-a546-63272097c717)
