### PR TITLE
Row totals number precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The package can be installed from `hex.pm` as follows:
 ```elixir
 def deps do
   [
-    {:luminous, "~> 1.4.0"}
+    {:luminous, "~> 1.4.1"}
   ]
 end
 ```

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "luminous",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "luminous",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "devDependencies": {
         "chart.js": "^3.3.0",

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "luminous",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The JavaScript client for the Luminous framework.",
   "license": "MIT",
   "main": "./assets/js/app.js",

--- a/dev/test_dashboard_live.ex
+++ b/dev/test_dashboard_live.ex
@@ -170,7 +170,12 @@ defmodule Luminous.Dashboards.TestDashboardLive do
           "foo" =>
             Query.Attributes.define(title: "Foo", order: 1, halign: :right, table_totals: :sum),
           "bar" =>
-            Query.Attributes.define(title: "Bar", order: 2, halign: :right, table_totals: :avg)
+            Query.Attributes.define(
+              title: "Bar",
+              order: 2,
+              halign: :right,
+              table_totals: {:avg, 1}
+            )
         }
       )
     end

--- a/lib/luminous/panel/table.ex
+++ b/lib/luminous/panel/table.ex
@@ -8,13 +8,25 @@ defmodule Luminous.Panel.Table do
       attrs
       |> Enum.sort_by(fn {_, attr} -> attr.order end)
       |> Enum.map(fn {label, attr} ->
-        %{
+        col_params = %{
           field: label,
           title: attr.title || label,
           hozAlign: attr.halign,
-          headerHozAlign: attr.halign,
-          bottomCalc: attr.table_totals
+          headerHozAlign: attr.halign
         }
+
+        case attr.table_totals do
+          nil ->
+            col_params
+
+          {totals_function, precision} ->
+            col_params
+            |> Map.put(:bottomCalc, totals_function)
+            |> Map.put(:bottomCalcParams, %{precision: precision})
+
+          totals_function ->
+            Map.put(col_params, :bottomCalc, totals_function)
+        end
       end)
 
     rows =

--- a/lib/luminous/query.ex
+++ b/lib/luminous/query.ex
@@ -11,6 +11,9 @@ defmodule Luminous.Query do
     This struct collects all the attributes that apply to a particular Dataset.
     It is specified in the `attrs` argument of `Luminous.Query.Result.new/2`.
     """
+    @type totals_function :: :sum | :avg | :min | :max | :count
+    @type decimal_precision :: non_neg_integer()
+
     @type t :: %__MODULE__{
             type: :line | :bar,
             order: non_neg_integer() | nil,
@@ -18,7 +21,7 @@ defmodule Luminous.Query do
             unit: binary(),
             title: binary(),
             halign: :left | :center | :right,
-            table_totals: :sum | :avg | :min | :max | :count
+            table_totals: totals_function() | {totals_function(), decimal_precision()}
           }
 
     @derive Jason.Encoder

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Luminous.MixProject do
   def project do
     [
       app: :luminous,
-      version: "1.4.0",
+      version: "1.4.1",
       elixir: ">= 1.12.0",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "luminous",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "The JavaScript client for the Luminous framework.",
 	"license": "MIT",
 	"module": "./dist/luminous.js",

--- a/test/luminous/live_test.exs
+++ b/test/luminous/live_test.exs
@@ -118,8 +118,7 @@ defmodule Luminous.LiveTest do
             field: "label",
             headerHozAlign: :center,
             hozAlign: :center,
-            title: "Label",
-            bottomCalc: nil
+            title: "Label"
           },
           %{
             field: "foo",
@@ -133,7 +132,8 @@ defmodule Luminous.LiveTest do
             headerHozAlign: :right,
             hozAlign: :right,
             title: "Bar",
-            bottomCalc: :avg
+            bottomCalc: :avg,
+            bottomCalcParams: %{precision: 1}
           }
         ],
         rows: [


### PR DESCRIPTION
This change gives the library's consumers the option to set the decimal precision for the row totals function result. That way the following issue is also addressed:
![image](https://github.com/elinverd/luminous/assets/951049/2cb7e138-63d5-4e7b-be40-c862a98a2d7d)
