### PR TITLE
Multi select dropdown

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -70,6 +70,14 @@
 		@apply text-left rounded-lg cursor-pointer hover:bg-slate-200
 	}
 
+	.lmn-multi-variable-dropdown-item-container {
+		@apply text-left rounded-lg cursor-pointer hover:bg-slate-200 px-4 py-3 flex items-center gap-2
+	}
+
+  .lmn-multi-variable-dropdown-checkbox {
+    @apply cursor-pointer text-slate-800 rounded focus:ring-0 focus:ring-offset-0
+  }
+
 	.lmn-variable-dropdown-item-content {
 		@apply px-4 py-3
 	}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6,11 +6,13 @@ import { LiveSocket } from "phoenix_live_view"
 import ChartJSHook from "./components/chartjs_hook"
 import TimeRangeHook from "./components/time_range_hook"
 import TableHook from "./components/table_hook"
+import MultiSelectVariableHook from "./components/multi_select_variable_hook"
 
 let Hooks = {
   ChartJSHook: new ChartJSHook(),
   TimeRangeHook: new TimeRangeHook(),
-  TableHook: new TableHook()
+  TableHook: new TableHook(),
+  MultiSelectVariableHook: new MultiSelectVariableHook()
 }
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")

--- a/assets/js/components/multi_select_state_hook.js
+++ b/assets/js/components/multi_select_state_hook.js
@@ -1,0 +1,31 @@
+function MultiSelectStateHook() {
+  this.mounted = function() {
+    this.state = {open: false, values: null}
+
+    document.getElementById(this.el.id).addEventListener('dropdownOpen', (e) => {
+      this.state.open = true
+      this.state.values = e.detail.values
+    })
+
+    // if the clicked item exists in the state, it is removed
+    // otherwise it is added to the state
+    document.getElementById(this.el.id).addEventListener('valueClicked', (e) => {
+      const index = this.state.values.indexOf(e.detail.value)
+
+      if (index > -1) {
+        this.state.values.splice(index, 1)
+      } else {
+        this.state.values.push(e.detail.value)
+      }
+    })
+
+    document.getElementById(this.el.id).addEventListener('clickAway', (e) => {
+      if (this.state.open) {
+        this.state.open = false
+        this.pushEventTo("#" + this.el.id, "variable_updated", {variable: e.detail.var_id, value: this.state.values})
+      }
+    })
+  }
+}
+
+export default MultiSelectStateHook;

--- a/assets/js/components/multi_select_variable_hook.js
+++ b/assets/js/components/multi_select_variable_hook.js
@@ -1,4 +1,4 @@
-function MultiSelectStateHook() {
+function MultiSelectVariableHook() {
   this.mounted = function() {
     this.state = {open: false, values: null}
 
@@ -28,4 +28,4 @@ function MultiSelectStateHook() {
   }
 }
 
-export default MultiSelectStateHook;
+export default MultiSelectVariableHook;

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -7,5 +7,8 @@ module.exports = {
     textOpacity: false,
     backgroundOpacity: false,
     borderOpacity: false
-  }
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+  ]
 }

--- a/dev/demo_dashboard_live.ex
+++ b/dev/demo_dashboard_live.ex
@@ -121,7 +121,8 @@ defmodule Luminous.Dashboards.DemoDashboardLive do
     ],
     variables: [
       Variable.define!(id: :multiplier_var, label: "Multiplier", module: Variables),
-      Variable.define!(id: :interval_var, label: "Interval", module: Variables)
+      Variable.define!(id: :interval_var, label: "Interval", module: Variables),
+      Variable.define!(id: :region_var, label: "Region", module: Variables, type: :multi)
     ]
 
   @impl true
@@ -158,6 +159,9 @@ defmodule Luminous.Dashboards.DemoDashboardLive do
     end
 
     def variable(:interval_var, %{param_name: _some_value}), do: ["hour", "day"]
+
+    def variable(:region_var, _), do: ["north", "south", "east", "west"]
+    def variable(:region_var2, _), do: ["north2", "south2", "east2", "west2"]
   end
 
   defmodule Queries do

--- a/dev/demo_dashboard_live.ex
+++ b/dev/demo_dashboard_live.ex
@@ -120,8 +120,8 @@ defmodule Luminous.Dashboards.DemoDashboardLive do
       )
     ],
     variables: [
-      Variable.define(:multiplier_var, "Multiplier", Variables),
-      Variable.define(:interval_var, "Interval", Variables)
+      Variable.define!(id: :multiplier_var, label: "Multiplier", module: Variables),
+      Variable.define!(id: :interval_var, label: "Interval", module: Variables)
     ]
 
   @impl true

--- a/dev/test_dashboard_live.ex
+++ b/dev/test_dashboard_live.ex
@@ -114,9 +114,9 @@ defmodule Luminous.Dashboards.TestDashboardLive do
       )
     ],
     variables: [
-      Variable.define(:var1, "Var 1", Variables),
-      Variable.define(:var2, "Var 2", Variables),
-      Variable.define(:var3, "Var 3", Variables)
+      Variable.define!(id: :var1, label: "Var 1", module: Variables),
+      Variable.define!(id: :var2, label: "Var 2", module: Variables),
+      Variable.define!(id: :var3, label: "Var 3", module: Variables)
     ]
 
   @impl true

--- a/dev/test_dashboard_live.ex
+++ b/dev/test_dashboard_live.ex
@@ -116,7 +116,8 @@ defmodule Luminous.Dashboards.TestDashboardLive do
     variables: [
       Variable.define!(id: :var1, label: "Var 1", module: Variables),
       Variable.define!(id: :var2, label: "Var 2", module: Variables),
-      Variable.define!(id: :var3, label: "Var 3", module: Variables)
+      Variable.define!(id: :var3, label: "Var 3", module: Variables),
+      Variable.define!(id: :multi_var, label: "Multi", module: Variables, type: :multi)
     ]
 
   @impl true
@@ -135,6 +136,7 @@ defmodule Luminous.Dashboards.TestDashboardLive do
     def variable(:var1, _), do: ["a", "b", "c"]
     def variable(:var2, _), do: ["1", "2", "3"]
     def variable(:var3, %{test_param: values}), do: values
+    def variable(:multi_var, _), do: ["north", "south", "east", "west"]
   end
 
   defmodule Queries do

--- a/dist/luminous.css
+++ b/dist/luminous.css
@@ -1339,6 +1339,172 @@ video {
   display: none;
 }
 
+[type='text'],[type='email'],[type='url'],[type='password'],[type='number'],[type='date'],[type='datetime-local'],[type='month'],[type='search'],[type='tel'],[type='time'],[type='week'],[multiple],textarea,select {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  background-color: #fff;
+  border-color: #6b7280;
+  border-width: 1px;
+  border-radius: 0px;
+  padding-top: 0.5rem;
+  padding-right: 0.75rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  --tw-shadow: 0 0 #0000;
+}
+
+[type='text']:focus, [type='email']:focus, [type='url']:focus, [type='password']:focus, [type='number']:focus, [type='date']:focus, [type='datetime-local']:focus, [type='month']:focus, [type='search']:focus, [type='tel']:focus, [type='time']:focus, [type='week']:focus, [multiple]:focus, textarea:focus, select:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+  --tw-ring-offset-width: 0px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: #2563eb;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  border-color: #2563eb;
+}
+
+input::-moz-placeholder, textarea::-moz-placeholder {
+  color: #6b7280;
+  opacity: 1;
+}
+
+input::placeholder,textarea::placeholder {
+  color: #6b7280;
+  opacity: 1;
+}
+
+::-webkit-datetime-edit-fields-wrapper {
+  padding: 0;
+}
+
+::-webkit-date-and-time-value {
+  min-height: 1.5em;
+}
+
+::-webkit-datetime-edit,::-webkit-datetime-edit-year-field,::-webkit-datetime-edit-month-field,::-webkit-datetime-edit-day-field,::-webkit-datetime-edit-hour-field,::-webkit-datetime-edit-minute-field,::-webkit-datetime-edit-second-field,::-webkit-datetime-edit-millisecond-field,::-webkit-datetime-edit-meridiem-field {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+select {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+  background-position: right 0.5rem center;
+  background-repeat: no-repeat;
+  background-size: 1.5em 1.5em;
+  padding-right: 2.5rem;
+  -webkit-print-color-adjust: exact;
+          print-color-adjust: exact;
+}
+
+[multiple] {
+  background-image: initial;
+  background-position: initial;
+  background-repeat: unset;
+  background-size: initial;
+  padding-right: 0.75rem;
+  -webkit-print-color-adjust: unset;
+          print-color-adjust: unset;
+}
+
+[type='checkbox'],[type='radio'] {
+  -webkit-appearance: none;
+     -moz-appearance: none;
+          appearance: none;
+  padding: 0;
+  -webkit-print-color-adjust: exact;
+          print-color-adjust: exact;
+  display: inline-block;
+  vertical-align: middle;
+  background-origin: border-box;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
+  flex-shrink: 0;
+  height: 1rem;
+  width: 1rem;
+  color: #2563eb;
+  background-color: #fff;
+  border-color: #6b7280;
+  border-width: 1px;
+  --tw-shadow: 0 0 #0000;
+}
+
+[type='checkbox'] {
+  border-radius: 0px;
+}
+
+[type='radio'] {
+  border-radius: 100%;
+}
+
+[type='checkbox']:focus,[type='radio']:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  --tw-ring-inset: var(--tw-empty,/*!*/ /*!*/);
+  --tw-ring-offset-width: 2px;
+  --tw-ring-offset-color: #fff;
+  --tw-ring-color: #2563eb;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+}
+
+[type='checkbox']:checked,[type='radio']:checked {
+  border-color: transparent;
+  background-color: currentColor;
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+[type='checkbox']:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+}
+
+[type='radio']:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
+}
+
+[type='checkbox']:checked:hover,[type='checkbox']:checked:focus,[type='radio']:checked:hover,[type='radio']:checked:focus {
+  border-color: transparent;
+  background-color: currentColor;
+}
+
+[type='checkbox']:indeterminate {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
+  border-color: transparent;
+  background-color: currentColor;
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+[type='checkbox']:indeterminate:hover,[type='checkbox']:indeterminate:focus {
+  border-color: transparent;
+  background-color: currentColor;
+}
+
+[type='file'] {
+  background: unset;
+  border-color: inherit;
+  border-width: 0;
+  border-radius: 0;
+  padding: 0;
+  font-size: unset;
+  line-height: inherit;
+}
+
+[type='file']:focus {
+  outline: 1px solid ButtonText;
+  outline: 1px auto -webkit-focus-ring-color;
+}
+
 *, ::before, ::after {
   --tw-border-spacing-x: 0;
   --tw-border-spacing-y: 0;
@@ -1681,6 +1847,36 @@ video {
   background-color: #e2e8f0;
 }
 
+.lmn-multi-variable-dropdown-item-container {
+  display: flex;
+  cursor: pointer;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+  text-align: left;
+}
+
+.lmn-multi-variable-dropdown-item-container:hover {
+  background-color: #e2e8f0;
+}
+
+.lmn-multi-variable-dropdown-checkbox {
+  cursor: pointer;
+  border-radius: 0.25rem;
+  color: #1e293b;
+}
+
+.lmn-multi-variable-dropdown-checkbox:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-offset-width: 0px;
+}
+
 .lmn-variable-dropdown-item-content {
   padding-left: 1rem;
   padding-right: 1rem;
@@ -1909,6 +2105,12 @@ video {
 
 .cursor-pointer {
   cursor: pointer;
+}
+
+.select-none {
+  -webkit-user-select: none;
+     -moz-user-select: none;
+          user-select: none;
 }
 
 .grid-cols-10 {

--- a/lib/luminous/components.ex
+++ b/lib/luminous/components.ex
@@ -271,9 +271,9 @@ defmodule Luminous.Components do
   @doc """
   This component is responsible for rendering the dropdown of the assigned variable.
   """
-  attr :variable, Variable, required: true
+  attr :variable, :map, required: true
 
-  def variable(assigns) do
+  def variable(%{variable: %{type: :single}} = assigns) do
     ~H"""
     <div id={"#{@variable.id}-dropdown"} class="relative" phx-click-away={hide_dropdown("#{@variable.id}-dropdown-content")}>
       <button class="lmn-variable-button" phx-click={show_dropdown("#{@variable.id}-dropdown-content")}>

--- a/lib/luminous/dashboard.ex
+++ b/lib/luminous/dashboard.ex
@@ -64,7 +64,7 @@ defmodule Luminous.Dashboard do
   def path(dashboard, socket, params) do
     var_params =
       Enum.map(dashboard.variables, fn var ->
-        {var.id, Keyword.get(params, var.id, var.current.value)}
+        {var.id, Keyword.get(params, var.id, Variable.extract_value(var.current))}
       end)
 
     time_range_params = [

--- a/lib/luminous/dashboard.ex
+++ b/lib/luminous/dashboard.ex
@@ -32,7 +32,7 @@ defmodule Luminous.Dashboard do
     path: [type: {:fun, 3}, required: true],
     action: [type: :atom, required: true],
     panels: [type: {:list, :map}, default: []],
-    variables: [type: {:list, {:struct, Variable}}, default: []],
+    variables: [type: {:list, :map}, default: []],
     time_range_selector: [type: {:struct, TimeRangeSelector}, default: %TimeRangeSelector{}],
     time_zone: [type: :string, default: @default_time_zone]
   ]

--- a/lib/luminous/live.ex
+++ b/lib/luminous/live.ex
@@ -53,14 +53,10 @@ defmodule Luminous.Live do
 
           # get variable values from params
           variables =
-            socket.assigns.dashboard.variables
-            |> Enum.map(fn var ->
-              if new_val = params["#{var.id}"] do
-                Variable.update_current(var, new_val)
-              else
-                var
-              end
-            end)
+            Enum.map(
+              socket.assigns.dashboard.variables,
+              &Variable.update_current(&1, params["#{&1.id}"])
+            )
 
           # update dashboard
           dashboard =
@@ -127,6 +123,8 @@ defmodule Luminous.Live do
             %{"variable" => variable, "value" => value},
             %{assigns: %{dashboard: dashboard}} = socket
           ) do
+        value = if value == [], do: "none", else: value
+
         {:noreply,
          push_patch(socket,
            to: Dashboard.path(dashboard, socket, [{String.to_existing_atom(variable), value}])

--- a/test/luminous/live_test.exs
+++ b/test/luminous/live_test.exs
@@ -209,6 +209,7 @@ defmodule Luminous.LiveTest do
           var1: "a",
           var2: 1,
           var3: "test_param_val_1",
+          multi_var: ["north", "south", "east", "west"],
           from: from,
           to: to
         )
@@ -238,6 +239,7 @@ defmodule Luminous.LiveTest do
           var1: "b",
           var2: 1,
           var3: "test_param_val_1",
+          multi_var: ["north", "south", "east", "west"],
           from: DateTime.to_unix(tr.from),
           to: DateTime.to_unix(tr.to)
         )
@@ -251,6 +253,7 @@ defmodule Luminous.LiveTest do
           var1: "b",
           var2: 3,
           var3: "test_param_val_1",
+          multi_var: ["north", "south", "east", "west"],
           from: DateTime.to_unix(tr.from),
           to: DateTime.to_unix(tr.to)
         )
@@ -262,6 +265,87 @@ defmodule Luminous.LiveTest do
 
       assert has_element?(view, "#var3-dropdown li", "test_param_val_1")
       assert has_element?(view, "#var3-dropdown li", "test_param_val_2")
+    end
+  end
+
+  describe "multi-select variables" do
+    setup do
+      # we use "Europe/Athens" because this is the time zone defined in TestDashboardLive module
+      tr = Luminous.TimeRange.yesterday("Europe/Athens")
+
+      %{from: DateTime.to_unix(tr.from), to: DateTime.to_unix(tr.to)}
+    end
+
+    test "when a single value is selected", %{conn: conn, from: from, to: to} do
+      {:ok, view, _} = live(conn, Routes.test_dashboard_path(conn, :index))
+
+      assert has_element?(view, "#multi_var-dropdown", "Multi: All")
+
+      view
+      |> element("#multi_var-dropdown")
+      |> render_hook("variable_updated", %{variable: "multi_var", value: ["north"]})
+
+      assert_patched(
+        view,
+        Routes.test_dashboard_path(conn, :index,
+          var1: "a",
+          var2: 1,
+          var3: "test_param_val_1",
+          multi_var: ["north"],
+          from: from,
+          to: to
+        )
+      )
+
+      assert has_element?(view, "#multi_var-dropdown", "Multi: north")
+    end
+
+    test "when two values are selected", %{conn: conn, from: from, to: to} do
+      {:ok, view, _} = live(conn, Routes.test_dashboard_path(conn, :index))
+
+      assert has_element?(view, "#multi_var-dropdown", "Multi: All")
+
+      view
+      |> element("#multi_var-dropdown")
+      |> render_hook("variable_updated", %{variable: "multi_var", value: ["north", "south"]})
+
+      assert_patched(
+        view,
+        Routes.test_dashboard_path(conn, :index,
+          var1: "a",
+          var2: 1,
+          var3: "test_param_val_1",
+          multi_var: ["north", "south"],
+          from: from,
+          to: to
+        )
+      )
+
+      assert has_element?(view, "#multi_var-dropdown", "Multi: 2 selected")
+    end
+
+    test "when no value is selected", %{conn: conn, from: from, to: to} do
+      {:ok, view, _} = live(conn, Routes.test_dashboard_path(conn, :index))
+
+      assert has_element?(view, "#multi_var-dropdown", "Multi: All")
+
+      view
+      |> element("#multi_var-dropdown")
+      |> render_hook("variable_updated", %{variable: "multi_var", value: []})
+
+      assert_patched(
+        view,
+        Routes.test_dashboard_path(conn, :index,
+          var1: "a",
+          var2: 1,
+          var3: "test_param_val_1",
+          multi_var: "none",
+          from: from,
+          to: to
+        )
+      )
+
+      assert has_element?(view, "#multi_var-dropdown", "Multi: None")
     end
   end
 end


### PR DESCRIPTION
This change introduces multi-select dropdown menus to `luminous`. 

The consumer can now define a `Variable` as `:multi` and the library will create a variable the dropdown menu of which consists of checkboxes. The user may select all, some or none of them and when he/she closes the menu, the selected options are included in the URL parameters and the displayed data is refreshed accordingly.