### PR TITLE
Add search functionality to multi select dropdown

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -70,6 +70,23 @@
 		@apply text-left rounded-lg cursor-pointer hover:bg-slate-200
 	}
 
+	.lmn-multi-variable-dropdown-search {
+		@apply flex items-center mb-2 px-2 h-10 gap-2 rounded-lg border border-gray-300 focus-within:ring-1 focus-within:ring-blue-600 focus-within:border-transparent
+	}
+
+	.lmn-multi-variable-dropdown-search-input {
+		@apply h-8 border-none focus:ring-0 grow
+	}
+
+	.lmn-multi-variable-dropdown-search-icon {
+		@apply h-5 w-5 mr-1
+	}
+
+
+	.lmn-multi-variable-dropdown-container {
+		@apply absolute hidden p-2 z-50 bg-white rounded-lg shadow-lg
+	}
+
 	.lmn-multi-variable-dropdown-item-container {
 		@apply text-left rounded-lg cursor-pointer hover:bg-slate-200 px-4 py-3 flex items-center gap-2
 	}

--- a/assets/js/components/multi_select_variable_hook.js
+++ b/assets/js/components/multi_select_variable_hook.js
@@ -25,6 +25,19 @@ function MultiSelectVariableHook() {
         this.pushEventTo("#" + this.el.id, "lmn_variable_updated", {variable: e.detail.var_id, value: this.state.values})
       }
     })
+
+    document.getElementById(this.el.id).addEventListener('itemSearch', (e) => {
+      const input = document.getElementById(e.detail.input_id)
+
+      for (const li of input.parentElement.parentElement.getElementsByTagName("li")) {
+        const label_text = li.querySelector("label span").textContent.toLowerCase()
+        if (label_text.includes(input.value.toLowerCase())) {
+          li.style.display = 'list-item'
+        } else {
+          li.style.display = 'none'
+        }
+      }
+    })
   }
 }
 

--- a/assets/js/components/multi_select_variable_hook.js
+++ b/assets/js/components/multi_select_variable_hook.js
@@ -27,14 +27,14 @@ function MultiSelectVariableHook() {
     })
 
     document.getElementById(this.el.id).addEventListener('itemSearch', (e) => {
-      const input = document.getElementById(e.detail.input_id)
+      const text_to_search = document.getElementById(e.detail.input_id).value.toLowerCase()
+      const list = document.getElementById(e.detail.list_id)
 
-      for (const li of input.parentElement.parentElement.getElementsByTagName("li")) {
-        const label_text = li.querySelector("label span").textContent.toLowerCase()
-        if (label_text.includes(input.value.toLowerCase())) {
-          li.style.display = 'list-item'
+      for (const list_item of list.children) {
+        if (list_item.textContent.toLowerCase().includes(text_to_search)) {
+          list_item.style.display = 'list-item'
         } else {
-          li.style.display = 'none'
+          list_item.style.display = 'none'
         }
       }
     })

--- a/dist/luminous.css
+++ b/dist/luminous.css
@@ -1847,6 +1847,62 @@ select {
   background-color: #e2e8f0;
 }
 
+.lmn-multi-variable-dropdown-search {
+  margin-bottom: 0.5rem;
+  display: flex;
+  height: 2.5rem;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+  border-width: 1px;
+  border-color: #d1d5db;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+.lmn-multi-variable-dropdown-search:focus-within {
+  border-color: transparent;
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+  --tw-ring-opacity: 1;
+  --tw-ring-color: rgb(37 99 235 / var(--tw-ring-opacity));
+}
+
+.lmn-multi-variable-dropdown-search-input {
+  height: 2rem;
+  flex-grow: 1;
+  border-style: none;
+}
+
+.lmn-multi-variable-dropdown-search-input:focus {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(0px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.lmn-multi-variable-dropdown-search-icon {
+  margin-right: 0.25rem;
+  height: 1.25rem;
+  width: 1.25rem;
+}
+
+.lmn-multi-variable-dropdown-container {
+  position: absolute;
+  z-index: 50;
+  display: none;
+  border-radius: 0.5rem;
+  background-color: #fff;
+  padding: 0.5rem;
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.flatpickr-day.lmn-multi-variable-dropdown-container {
+  visibility: hidden;
+}
+
 .lmn-multi-variable-dropdown-item-container {
   display: flex;
   cursor: pointer;
@@ -2064,6 +2120,10 @@ select {
   height: 2rem;
 }
 
+.max-h-96 {
+  max-height: 24rem;
+}
+
 .w-5 {
   width: 1.25rem;
 }
@@ -2078,6 +2138,11 @@ select {
 
 .w-full {
   width: 100%;
+}
+
+.w-max {
+  width: -moz-max-content;
+  width: max-content;
 }
 
 .max-w-screen-lg {
@@ -2184,6 +2249,10 @@ select {
   --tw-space-y-reverse: 0;
   margin-top: calc(2rem * calc(1 - var(--tw-space-y-reverse)));
   margin-bottom: calc(2rem * var(--tw-space-y-reverse));
+}
+
+.overflow-auto {
+  overflow: auto;
 }
 
 .truncate {

--- a/dist/luminous.js
+++ b/dist/luminous.js
@@ -43773,6 +43773,17 @@ function MultiSelectVariableHook() {
         this.pushEventTo("#" + this.el.id, "lmn_variable_updated", { variable: e.detail.var_id, value: this.state.values });
       }
     });
+    document.getElementById(this.el.id).addEventListener("itemSearch", (e) => {
+      const input2 = document.getElementById(e.detail.input_id);
+      for (const li of input2.parentElement.parentElement.getElementsByTagName("li")) {
+        const label_text = li.querySelector("label span").textContent.toLowerCase();
+        if (label_text.includes(input2.value.toLowerCase())) {
+          li.style.display = "list-item";
+        } else {
+          li.style.display = "none";
+        }
+      }
+    });
   };
 }
 var multi_select_variable_hook_default = MultiSelectVariableHook;

--- a/env/dev/dashboard.ex
+++ b/env/dev/dashboard.ex
@@ -28,7 +28,18 @@ defmodule Luminous.Dev.DashboardLive do
 
     def variable(:interval_var, _), do: ["hour", "day"]
 
-    def variable(:region_var, _), do: ["north", "south", "east", "west"]
+    def variable(:region_var, _),
+      do: [
+        "north",
+        "south",
+        "east",
+        "west",
+        "north west",
+        "south west",
+        "north east",
+        "south east"
+      ]
+
     def variable(:region_var2, _), do: ["north2", "south2", "east2", "west2"]
   end
 
@@ -316,7 +327,13 @@ defmodule Luminous.Dev.DashboardLive do
     variables: [
       Variable.define!(id: :multiplier_var, label: "Multiplier", module: Variables),
       Variable.define!(id: :interval_var, label: "Interval", module: Variables),
-      Variable.define!(id: :region_var, label: "Region", module: Variables, type: :multi)
+      Variable.define!(
+        id: :region_var,
+        label: "Region",
+        module: Variables,
+        type: :multi,
+        search: true
+      )
     ]
 
   @impl Luminous.Dashboard

--- a/lib/luminous/components.ex
+++ b/lib/luminous/components.ex
@@ -365,7 +365,10 @@ defmodule Luminous.Components do
             autocomplete="off"
             phx-change={
               JS.dispatch("itemSearch",
-                detail: %{"input_id" => "#{@variable.id}-dropdown-search-input"}
+                detail: %{
+                  "input_id" => "#{@variable.id}-dropdown-search-input",
+                  "list_id" => "#{@variable.id}-items-list"
+                }
               )
             }
           />
@@ -384,7 +387,7 @@ defmodule Luminous.Components do
             />
           </svg>
         </div>
-        <ul class="flex flex-col max-h-96 overflow-auto">
+        <ul id={"#{@variable.id}-items-list"} class="flex flex-col max-h-96 overflow-auto">
           <li
             :for={%{label: label, value: value} <- @variable.values}
             class="inline-block w-max"

--- a/lib/luminous/components.ex
+++ b/lib/luminous/components.ex
@@ -355,34 +355,55 @@ defmodule Luminous.Components do
         </svg>
       </button>
       <!-- Dropdown content -->
-      <div id={"#{@variable.id}-dropdown-content"} class="absolute hidden">
-        <ul class="lmn-variable-dropdown">
-          <%= for %{label: label, value: value} <- @variable.values do %>
-            <li id={"#{@variable.id}-#{value}"} class="">
-              <label
-                for={"#{@variable.id}-#{value}-checkbox"}
-                class="lmn-multi-variable-dropdown-item-container"
-              >
-                <%= if value in Variable.extract_value(@variable.current) do %>
-                  <input
-                    type="checkbox"
-                    id={"#{@variable.id}-#{value}-checkbox"}
-                    phx-click={JS.dispatch("valueClicked", detail: %{"value" => value})}
-                    class="lmn-multi-variable-dropdown-checkbox"
-                    checked
-                  />
-                <% else %>
-                  <input
-                    type="checkbox"
-                    id={"#{@variable.id}-#{value}-checkbox"}
-                    phx-click={JS.dispatch("valueClicked", detail: %{"value" => value})}
-                    class="lmn-multi-variable-dropdown-checkbox"
-                  />
-                <% end %>
-                <span class="select-none"><%= label %></span>
-              </label>
-            </li>
-          <% end %>
+      <div id={"#{@variable.id}-dropdown-content"} class="lmn-multi-variable-dropdown-container">
+        <div :if={Variable.show_search?(@variable)} class="lmn-multi-variable-dropdown-search">
+          <input
+            id={"#{@variable.id}-dropdown-search-input"}
+            type="text"
+            placeholder={"Search #{String.downcase(@variable.label)}..."}
+            class="lmn-multi-variable-dropdown-search-input"
+            autocomplete="off"
+            phx-change={
+              JS.dispatch("itemSearch",
+                detail: %{"input_id" => "#{@variable.id}-dropdown-search-input"}
+              )
+            }
+          />
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="lmn-multi-variable-dropdown-search-icon"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+            />
+          </svg>
+        </div>
+        <ul class="flex flex-col max-h-96 overflow-auto">
+          <li
+            :for={%{label: label, value: value} <- @variable.values}
+            class="inline-block w-max"
+            id={"#{@variable.id}-#{label}"}
+          >
+            <label
+              for={"#{@variable.id}-#{value}-checkbox"}
+              class="lmn-multi-variable-dropdown-item-container"
+            >
+              <input
+                type="checkbox"
+                id={"#{@variable.id}-#{value}-checkbox"}
+                phx-click={JS.dispatch("valueClicked", detail: %{"value" => value})}
+                class="lmn-multi-variable-dropdown-checkbox"
+                checked={value in Variable.extract_value(@variable.current)}
+              />
+              <span class="select-none"><%= label %></span>
+            </label>
+          </li>
         </ul>
       </div>
     </div>

--- a/lib/luminous/panel/stat.ex
+++ b/lib/luminous/panel/stat.ex
@@ -37,9 +37,6 @@ defmodule Luminous.Panel.Stat do
       <% %{stats: [_ | _] = stats} -> %>
         <div id={"#{Utils.dom_id(@panel)}-stat-values"} class={stats_grid_structure(length(stats))}>
           <%= for {column, index} <- Enum.with_index(stats) do %>
-            <%= if Utils.dom_id(@panel) == "panel-p11" do %>
-              <% IO.inspect(stats) %>
-            <% end %>
             <div class="flex flex-col items-center">
               <div class="grow">
                 <p id={"#{Utils.dom_id(@panel)}-stat-#{index}-column-title"} class="text-lg">

--- a/lib/luminous/variable.ex
+++ b/lib/luminous/variable.ex
@@ -40,6 +40,7 @@ defmodule Luminous.Variable do
     module: [type: :atom, required: true],
     type: [type: {:in, [:single, :multi]}, default: :single],
     multi_default: [type: {:in, [:all, :none]}, default: :all],
+    search: [type: :boolean, default: false],
     hidden: [type: :boolean, default: false]
   ]
 
@@ -184,4 +185,11 @@ defmodule Luminous.Variable do
 
     %{var | current: new_values}
   end
+
+  @doc """
+  Returns true if the variable was declared to include a search field for the listed items,
+  otherwise false.
+  """
+  @spec show_search?(t()) :: boolean()
+  def show_search?(%{search: value}), do: value
 end


### PR DESCRIPTION
There are cases a multi-select dropdown has a lot of items and this makes it quite hard to find a specific item and select it.

With this change, the consumer can optionally add a search input at the top of the multi-select dropdown menu, which can help the user search the wanted item(s).